### PR TITLE
fixed the bug with pulling the same appointment twice

### DIFF
--- a/appointment-svc/controllers/appointment-controller.ts
+++ b/appointment-svc/controllers/appointment-controller.ts
@@ -179,6 +179,7 @@ class AppoinmentController {
         gte: currentDate,
         lte: targetDate,
       },
+      status: AppointmentStatus.BOOKED,
     };
 
     try {

--- a/rescheduling-service/src/services/appointmentQueueConsumer.ts
+++ b/rescheduling-service/src/services/appointmentQueueConsumer.ts
@@ -11,6 +11,8 @@ async function consumeAppointmentQueue() {
     const queue = "appointments";
     await channel.assertQueue(queue, { durable: false });
 
+    await channel.prefetch(1);
+
     console.log(" [*] Waiting for messages in %s. To exit press CTRL+C", queue);
 
     channel.consume(queue, async (msg) => {
@@ -39,7 +41,7 @@ async function consumeAppointmentQueue() {
           { isPending: true },
         );
 
-        await NotificationService.sendReschedulingPrompt(
+        NotificationService.sendReschedulingPrompt(
           appointment,
           availableAppointment,
         );


### PR DESCRIPTION
Basically the problem was that the rmq queue was not pulling one appointment at a time

I also made one change in appointment controller because getAvailableAppointments was not specifying the status of the appointment. I set it to BOOKED, but I think it should be rather 'not CANCELED' because it might also be CONFIRMED

fixes #49 